### PR TITLE
feat(ingest-api): implement HTTP → Kafka ingestion behind nginx LB

### DIFF
--- a/contracts/src/main/java/com/pk/contracts/EventEnvelope.java
+++ b/contracts/src/main/java/com/pk/contracts/EventEnvelope.java
@@ -4,13 +4,15 @@ import java.time.Instant;
 
 public record EventEnvelope (
         String tenantId,
-        String source,
+        Source source,
         String eventType,
         String eventID,
         Instant occurredAt,
         Instant ingestedAt,
         int schemaVersion,
-        Object payload
+        Object payload,
+
+        String correlationId
 
 ){
 }

--- a/contracts/src/main/java/com/pk/contracts/EventEnvelopeValidator.java
+++ b/contracts/src/main/java/com/pk/contracts/EventEnvelopeValidator.java
@@ -6,15 +6,22 @@ import java.util.List;
 public final class EventEnvelopeValidator {
     private EventEnvelopeValidator(){};
 
+    public static void validateOrThrow(EventEnvelope ev){
+        List<String> errors = validate(ev);
+        if(!errors.isEmpty()){
+            throw new IllegalArgumentException("Invalid EventEnvelop: " + String.join("; ", errors));
+        }
+    }
+
     public static List<String> validate(EventEnvelope ev){
         List<String> errors = new ArrayList<>();
         if(ev == null){
             return List.of("Event is null.");
         }
-        if(ev.tenantId().isEmpty()) errors.add("tenantId is required");
-        if(ev.source().isEmpty()) errors.add("source is required");
-        if(ev.eventType().isEmpty()) errors.add("eventType is required");
-        if(ev.eventID().isEmpty()) errors.add("eventId is required");
+        if(ev.tenantId() == null || ev.tenantId().trim().isEmpty()) errors.add("tenantId is required");
+        if(ev.source() == null) errors.add("source is required");
+        if(ev.eventType() == null || ev.eventType().trim().isEmpty()) errors.add("eventType is required");
+        if(ev.eventID() == null || ev.eventID().trim().isEmpty()) errors.add("eventId is required");
 
         if(ev.occurredAt() == null) errors.add("occurredAt is required");
         if(ev.ingestedAt() == null) errors.add("ingestedAt is required");

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,22 +17,27 @@ services:
   # Kafka (KRaft, single-node)
   # ----------------------------
   kafka:
-    image: bitnami/kafka:3.7
+    image: apache/kafka:3.7.0
     container_name: kafka
     ports:
       - "9092:9092"   # optional: host access
-      - "9094:9094"   # optional: external listener
     environment:
-      - KAFKA_ENABLE_KRAFT=yes
-      - KAFKA_CFG_NODE_ID=1
-      - KAFKA_CFG_PROCESS_ROLES=broker,controller
-      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
-      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093,EXTERNAL://:9094
-      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092,EXTERNAL://localhost:9094
-      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT
-      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=1@kafka:9093
-      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true
-      - KAFKA_CFG_NUM_PARTITIONS=12
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:9093
+
+      # single-node safety settings
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+
+      # your default partitions
+      KAFKA_NUM_PARTITIONS: 12
     volumes:
       - kafka_data:/bitnami/kafka
 
@@ -61,6 +66,29 @@ services:
       - POSTGRES_PASSWORD=ingestion
     volumes:
       - postgres_data:/var/lib/postgresql/data
+
+  # ----------------------------
+  # Core services
+  # ----------------------------
+  ingest-api-1:
+    build:
+      context: ./services/ingest-api
+    container_name: ingest-api-1
+    environment:
+      - KAFKA_BOOTSTRAP_SERVERS=kafka:9092
+      - KAFKA_TOPIC_MAIN=events.ingest.v1
+    depends_on:
+      - kafka
+
+  ingest-api-2:
+    build:
+      context: ./services/ingest-api
+    container_name: ingest-api-2
+    environment:
+      - KAFKA_BOOTSTRAP_SERVERS=kafka:9092
+      - KAFKA_TOPIC_MAIN=events.ingest.v1
+    depends_on:
+      - kafka
 
 volumes:
   kafka_data:

--- a/infra/nginx/nginx.conf
+++ b/infra/nginx/nginx.conf
@@ -1,0 +1,25 @@
+events {}
+
+http {
+  upstream ingest_upstream {
+    server ingest-api-1:8080;
+    server ingest-api-2:8080;
+  }
+
+  server {
+    listen 80;
+
+    location /health {
+      return 200 "ok\n";
+    }
+
+    location / {
+      proxy_pass http://ingest_upstream;
+      proxy_http_version 1.1;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header Connection "";
+    }
+  }
+}

--- a/services/ingest-api/Dockerfile
+++ b/services/ingest-api/Dockerfile
@@ -1,0 +1,5 @@
+FROM eclipse-temurin:17-jre
+WORKDIR /app
+COPY target/app.jar /app/app.jar
+EXPOSE 8080
+ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/services/ingest-api/pom.xml
+++ b/services/ingest-api/pom.xml
@@ -4,14 +4,67 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.example</groupId>
+    <!--<groupId>org.example</groupId>
     <artifactId>ingest-api</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0-SNAPSHOT</version>-->
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.3.8</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>com.pk</groupId>
+    <artifactId>ingest-api</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <java.version>17</java.version>
     </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.pk</groupId>
+            <artifactId>contracts</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>app</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/services/ingest-api/src/main/java/com/pk/ingestapi/IngestApiApplication.java
+++ b/services/ingest-api/src/main/java/com/pk/ingestapi/IngestApiApplication.java
@@ -1,0 +1,12 @@
+package com.pk.ingestapi;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class IngestApiApplication {
+    public static void main(String[] args){
+        SpringApplication.run(IngestApiApplication.class, args);
+    }
+
+}

--- a/services/ingest-api/src/main/java/com/pk/ingestapi/api/IngestController.java
+++ b/services/ingest-api/src/main/java/com/pk/ingestapi/api/IngestController.java
@@ -1,0 +1,52 @@
+package com.pk.ingestapi.api;
+
+import com.pk.contracts.EventEnvelope;
+import com.pk.contracts.EventEnvelopeValidator;
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/v1/tenants/{tenantId}")
+public class IngestController {
+
+    private final KafkaTemplate<String, EventEnvelope> kafkaTemplate;
+    private final String topic;
+
+
+    public IngestController(KafkaTemplate<String, EventEnvelope> kafkaTemplate, @Value("${kafka.topic.main}") String topic){
+        this.kafkaTemplate = kafkaTemplate;
+        this.topic = topic;
+    }
+
+    @PostMapping("/events")
+    public ResponseEntity<?> ingestSingleEvent(@PathVariable String tenantId, @Valid @RequestBody IngestEventRequest request){
+
+        EventEnvelope eventEnvelop = new EventEnvelope(tenantId,
+                request.source(),
+                request.eventType(),
+                request.eventId(),
+                request.occurredAt(),
+                Instant.now(),
+                request.schemaVersion() <= 0 ? 1 : request.schemaVersion(),
+                request.payload(),
+                request.correlationId() != null ? request.correlationId() : UUID.randomUUID().toString()
+        );
+
+        EventEnvelopeValidator.validateOrThrow(eventEnvelop);
+
+        //publish with key=tenantId (topic, key, data)
+        kafkaTemplate.send(topic, tenantId, eventEnvelop);
+        return ResponseEntity.accepted().body(new IngestResponse(UUID.randomUUID().toString(), "ACCEPTED"));
+    }
+
+    record IngestResponse(String ingestId, String status){
+    }
+
+
+}

--- a/services/ingest-api/src/main/java/com/pk/ingestapi/api/IngestEventRequest.java
+++ b/services/ingest-api/src/main/java/com/pk/ingestapi/api/IngestEventRequest.java
@@ -1,0 +1,18 @@
+package com.pk.ingestapi.api;
+
+import com.pk.contracts.Source;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.Instant;
+
+public record IngestEventRequest (
+    @NotNull Source source,
+    @NotBlank String eventType,
+    @NotBlank String eventId,
+    @NotNull Instant occurredAt,
+
+    int schemaVersion,
+
+    @NotNull Object payload,
+    String correlationId
+){ }

--- a/services/ingest-api/src/main/resources/application.yml
+++ b/services/ingest-api/src/main/resources/application.yml
@@ -1,0 +1,19 @@
+server:
+  port : 8080
+
+kafka:
+  topic:
+    main: ${KAFKA_TOPIC_MAIN:events.ingest.v1}
+
+spring:
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:kafka:9092}
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info


### PR DESCRIPTION
- Added Dockerfile for ingest-api
- Configured Apache Kafka (KRaft mode)
- Added nginx reverse proxy load balancer
- Verified round-robin distribution across 2 instances
- Confirmed tenantId-based partitioning in Kafka